### PR TITLE
[IMP] #681 show ps.time.line#unit_amount by default

### DIFF
--- a/ps_landing_page/models/hr_employee_landing_page.py
+++ b/ps_landing_page/models/hr_employee_landing_page.py
@@ -301,4 +301,7 @@ class HrEmployeeLandingPage(models.TransientModel):
             "view_id": tree_id,
             "target": "current",
             "domain": [("id", "in", entries)],
+            "context": {
+                "ps_time_line_hide_amount": True,
+            },
         }

--- a/ps_timesheet_invoicing/views/ps_time_line.xml
+++ b/ps_timesheet_invoicing/views/ps_time_line.xml
@@ -25,6 +25,7 @@
                     groups="ps_timesheet_invoicing.group_timesheet_manager,ps_timesheet_invoicing.group_chargecode_time_admin,ps_project.group_ps_invoicing"
                     invisible="context.get('ps_time_line_hide_amount')"
                 />
+                <field name="currency_id" invisible="1" />
                 <field name="state" />
             </tree>
         </field>

--- a/ps_timesheet_invoicing/views/ps_time_line.xml
+++ b/ps_timesheet_invoicing/views/ps_time_line.xml
@@ -3,14 +3,14 @@
     <record id="view_ps_time_line_tree" model="ir.ui.view">
         <field name="model">ps.time.line</field>
         <field name="arch" type="xml">
-            <tree string="Analytic Entries">
+            <tree>
                 <field name="date" optional="show" />
                 <field name="operating_unit_id" />
                 <field name="project_id" />
                 <field name="task_id" />
                 <field name="date_of_last_wip" />
                 <field name="week_id" string="Timesheet Week" />
-                <field name="unit_amount" sum="Quantity" optional="hide" />
+                <field name="unit_amount" sum="Quantity" optional="show" />
                 <field name="product_uom_id" optional="show" />
                 <field name="partner_id" optional="hide" />
                 <field
@@ -18,7 +18,13 @@
                     groups="base.group_multi_company"
                     optional="show"
                 />
-                <field name="amount" sum="Total" optional="show" />
+                <field
+                    name="amount"
+                    sum="Total"
+                    optional="show"
+                    groups="ps_timesheet_invoicing.group_timesheet_manager,ps_timesheet_invoicing.group_chargecode_time_admin,ps_project.group_ps_invoicing"
+                    invisible="context.get('ps_time_line_hide_amount')"
+                />
                 <field name="state" />
             </tree>
         </field>


### PR DESCRIPTION
this hides the amount column in ps.time.line lists for users not in groups ps_timesheet_invoicing.group_timesheet_manager, ps_timesheet_invoicing.group_chargecode_time_admin, ps_project.group_ps_invoicing, and always hides it when coming from the landing page.

And I took the liberty to add the currency_id field invisibly to the tree, this causes the amount column to be formatted as monetary, making it clear that this one is about money, the other about a quantity in the uom shown right after it.