### PR TITLE
[FIX] #705 forbid reviewing one's own timesheet

### DIFF
--- a/ps_holidays/tests/test_ps_holidays.py
+++ b/ps_holidays/tests/test_ps_holidays.py
@@ -4,6 +4,7 @@ from odoo.tests.common import Form, TransactionCase
 class TestPsHolidays(TransactionCase):
     def setUp(self):
         super().setUp()
+        self.admin = self.env.ref("base.user_admin")
         self.user = self.env.ref("base.user_demo")
         self.timesheet = self.env["hr_timesheet.sheet"].with_user(self.user).create({})
         self.leave_type = self.env.ref("hr_holidays.holiday_status_cl")
@@ -26,7 +27,7 @@ class TestPsHolidays(TransactionCase):
         leaves = self.env["hr.leave"].search(
             [("employee_id.user_id", "=", self.user.id)]
         )
-        self.timesheet.sudo().action_timesheet_done()
+        self.timesheet.with_user(self.admin).action_timesheet_done()
         self.leave_type.refresh()
         self.assertEqual(self.leave_type.with_user(self.user).leaves_taken, 7)
         new_leaves = (
@@ -36,7 +37,7 @@ class TestPsHolidays(TransactionCase):
         self.assertTrue(sum(new_leaves.mapped("number_of_days")), 7)
         # the 6 are from demo data sick leave, which doesn't have allocation
         self.assertEqual(self.user.employee_id.allocation_used_count, 7 + 6)
-        self.timesheet.sudo().action_timesheet_draft()
+        self.timesheet.with_user(self.admin).action_timesheet_draft()
         self.assertFalse(new_leaves.exists())
         self.leave_type.refresh()
         self.assertEqual(self.leave_type.with_user(self.user).leaves_taken, 0)


### PR DESCRIPTION
up to now, anyone with write permissions on the sheet could approve any timesheet when the review policy was something else than 'HR Officer' bypassing the UI and doing an XMLRPC request. I tightened that.

Note that the base module uses the same check for refusing and resetting to draft, so that's by now also forbidden for your own timesheet if you're not timesheet managerX. Let me know if that's a problem to fix or a feature.